### PR TITLE
Stream output to buffer asynchronously 

### DIFF
--- a/lua/flow/init.lua
+++ b/lua/flow/init.lua
@@ -18,8 +18,7 @@ local function run(filetype, code)
     return
   end
 
-  local out = vim.fn.system(c)
-  output.handle_output(out, setup_options.output)
+  output.handle_output(c, setup_options.output)
 end
 
 local function handle_md_file(lines)
@@ -66,8 +65,7 @@ local function run_custom_cmd(suffix)
   end
 
   local c = cmd.custom_cmd(suffix)
-  local out = vim.fn.system(c)
-  output.handle_output(out, setup_options.output)
+  output.handle_output(c, setup_options.output)
 end
 
 local function run_last_custom_cmd()
@@ -78,8 +76,7 @@ local function run_last_custom_cmd()
     return
   end
 
-  local out = vim.fn.system(c)
-  output.handle_output(out, setup_options.output)
+  output.handle_output(c, setup_options.output)
 end
 
 local function show_last_output()

--- a/lua/flow/output.lua
+++ b/lua/flow/output.lua
@@ -180,6 +180,9 @@ local function stream_output(cmd, options)
 
     vim.api.nvim_buf_set_lines(buffer, -1, -1, false, data)
     buf_contents = vim.api.nvim_buf_get_lines(buffer, 0, -1, false)
+    last_output = buf_contents
+
+    -- resize the window to fit the contents
     vim.api.nvim_win_set_config(win, get_output_win_config(buf_contents, options))
 
     -- scroll to the bottom of the buffer
@@ -234,7 +237,11 @@ local function show_last_output(options)
     return
   end
 
-  handle_output(last_output, options)
+  -- this is a quick hack to simply print the last output, by reusing the
+  -- handle_output function
+  last_output_str = table.concat(last_output, "\n")
+  local cmd = "cat <<EOF\n" .. last_output_str .. "\nEOF\n"
+  handle_output(cmd, options)
 end
 
 return {


### PR DESCRIPTION
Until now, when the command was executed, we would wait until the
program exists, to print the output to the buffer. So, after executing a
slightly long-running command, you'd have to wait for an awkward few
seconds until you saw any output.

This commit changes that by streaming the output to the buffer as and
when something is written to `STDOUT`. This way, the user will see
some kind of progress while the command is executing.

This was possible with the help of Neovim's `jobstart()` function. This
lets us run the command asynchronously and sends us callback signals
when something is written to `STDOUT`, `STDERR`, or the command exits.

---

Fixes #21 