### PR TITLE
Edit custom commands in a floating window

### DIFF
--- a/lua/flow/cmd.lua
+++ b/lua/flow/cmd.lua
@@ -1,6 +1,6 @@
 local vars = require('flow.vars')
 local sql = require('flow.sql')
-local util = require('flow.util')
+local windows = require('flow.windows')
 
 local DATA_DIR = vim.fn.stdpath("data")
 local CUSTOM_CMD_FILE = DATA_DIR .. "/" .. "run_code_custom_cmd_%s"
@@ -26,25 +26,12 @@ local filetype_cmd_map = {
 -- command
 local function set_custom_cmd(suffix)
   if suffix == nil then
-    print("flow: you need to provide an alias for the custom command (example: :RunCodeSetCustomCmd 1)")
+    print("flow: you need to provide an alias for the custom command (example: :FlowSetCustomCmd 1)")
     return
   end
 
   local file_name = string.format(CUSTOM_CMD_FILE, suffix)
-  local is_new_file = not util.file_exists(file_name)
-
-  if is_new_file then
-    local help_text = vars.vars_help_text()
-
-    local file = io.open(file_name, "w")
-    file:write("\n\n" .. help_text)
-    file:close()
-  end
-
-  vim.cmd(custom_command_default_split .. ' ' .. file_name)
-  custom_command_win = vim.api.nvim_get_current_win()
-  custom_command_buf = vim.api.nvim_get_current_buf()
-  vim.bo.filetype = custom_command_filetype
+  windows.open_custom_cmd_window(file_name, custom_command_filetype)
 end
 
 -- callback function that gets triggered when the command is saved

--- a/lua/flow/vars.lua
+++ b/lua/flow/vars.lua
@@ -43,10 +43,11 @@ end
 
 local function vars_help_text()
   local help_text = "# Variables available for use:\n"
-  for key, func in pairs(cmd_variables) do
+  for key, _ in pairs(cmd_variables) do
     help_text = help_text .. string.format("#  - $%s\n", key)
   end
 
+  help_text = help_text .. "#\n# save the changes and press <esc> to close the window\n"
   return help_text
 end
 

--- a/lua/flow/windows.lua
+++ b/lua/flow/windows.lua
@@ -1,0 +1,60 @@
+local util = require('flow.util')
+local vars = require('flow.vars')
+
+local function open_custom_cmd_window(file_name, file_type)
+  local win_cols = vim.api.nvim_get_option('columns')
+  local win_rows = vim.api.nvim_get_option('lines')
+  local screen_coverage = 0.4
+  local width = math.floor(win_cols * screen_coverage)
+  local height = math.floor(win_rows * screen_coverage)
+  local col = math.floor((win_cols - width) / 2)
+  local row = math.floor((win_rows - height) / 2)
+
+  local output_win_config = {
+    relative = 'editor', border = 'double', style = 'minimal',
+    title = 'flow: custom cmd', title_pos = 'center',
+    width = width, height = height, col = col, row = row,
+  }
+
+  local win = vim.api.nvim_open_win(0, true, output_win_config)
+  local buffer = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_win_set_buf(win, buffer)
+
+  if not util.file_exists(file_name) then
+    local help_text = vars.vars_help_text()
+    local file = io.open(file_name, "w")
+    if file == nil then
+      print(string.format("flow: couldn't open file '%s' for writing", file_name))
+      return
+    end
+
+    file:write("\n\n" .. help_text)
+    file:close()
+  end
+
+  vim.cmd('edit ' .. file_name)
+  vim.bo.filetype = file_type
+
+  vim.api.nvim_create_autocmd({'BufDelete', 'BufLeave'}, {
+    buffer = buffer,
+    callback = function()
+      if vim.api.nvim_buf_is_valid(buffer) then
+        vim.api.nvim_buf_delete(buffer, {force = false})
+      end
+    end
+  })
+
+  vim.api.nvim_buf_set_keymap(buffer, "n", "<esc>", ":q<cr>", {
+    callback = function()
+      if vim.api.nvim_buf_get_option(buffer, "modified") then
+        return
+      end
+
+      vim.api.nvim_buf_delete(buffer, {force = false})
+    end,
+  })
+end
+
+return {
+  open_custom_cmd_window = open_custom_cmd_window,
+}

--- a/plugin/flow.vim
+++ b/plugin/flow.vim
@@ -16,9 +16,6 @@ command! FlowRunMDBlock lua require('flow').run_block()
 " trigger reset of output when the output buffer is manually closed
 autocmd FileType run-code-output autocmd BufDelete <buffer> lua require('flow.output').reset_output_win()
 
-" close the custom command window on save
-autocmd BufWritePost,BufLeave,BufDelete *run_code_custom_cmd_* lua require('flow.cmd').close_custom_cmd_win()
-
 let &cpo = s:save_cpo
 unlet s:save_cpo
 


### PR DESCRIPTION
Previously, the edit window for custom commands was spawned using "10split". This would create a small split buffer. But this forced us to use global autocommands to clean up this window/buffer on save and exit.

This commit changes that by taking a more modern approach by spawning a floating window for editing custom commands. The cleanup is done using a buffer-local autocommand

Closes #31